### PR TITLE
version bump 0.5.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "apistar" %}
-{% set version = "0.5.9" %}
-{% set sha256 = "ca0951d9bc927e77c70365935b57d6fc26b614a152cc1e9a35c377ae9d4b4c2a" %}
+{% set version = "0.5.10" %}
+{% set sha256 = "4d7efd375dab42f9fd5d2d44cba92addbdfac78c05c7aa7beb2e3ca153416db4" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
-> this gave me a `No changes made. This feedstock is up-to-date.` message. Is that expected?
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Please note that the build for this package is currently failing because I pushed a branch (for the previous version bump to `0.5.9`) to the repo by accident, and it go build and uploaded. The one from https://github.com/conda-forge/apistar-feedstock/pull/1 failed then, because the files were already present. Sorry